### PR TITLE
Fixed search by code templates

### DIFF
--- a/PP2/scriptorium/pages/api/blogposts/index.js
+++ b/PP2/scriptorium/pages/api/blogposts/index.js
@@ -97,7 +97,6 @@ export default async function handler(req, res) {
                         some: {
                             title: {
                                 contains: templateTitle,
-                                mode: "insensitive",
                             },
                         },
                     }


### PR DESCRIPTION
mode: "insensitive" was causing a Prisma error